### PR TITLE
fix typo in main script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "particleplate",
   "version": "0.1.0",
   "description": "A TypeScript+React+ReactRouter+Redux+MaterialUI+PostCSS boilerplate",
-  "main": "api/server.ts",
+  "main": "api/server.js",
   "scripts": {
     "watch": "node ./watcher.js",
     "build": "node ./build.js",


### PR DESCRIPTION
it was .ts but in reality is currently .js in that folder.
I noticed this when trying to import this project to https://codesandbox.io/s/github/handicraftsman/particleplate with the error `Cannot find the specified entry point: 'api/server.ts'. Please specify one in 'package.json#main' or create a file at the specified entry point.
`